### PR TITLE
Added check to move Doorbell's button

### DIFF
--- a/app/views/about/show.html
+++ b/app/views/about/show.html
@@ -16,7 +16,7 @@
             };
             (function(w, d, t) {
                 var hasLoaded = false;
-                function l() { if (hasLoaded) { return; } hasLoaded = true; window.doorbellOptions.windowLoaded = true; var g = d.createElement(t);g.id = 'doorbellScript';g.type = 'text/javascript';g.async = true;g.src = 'https://embed.doorbell.io/button/'+window.doorbellOptions['id']+'?t='+(new Date().getTime());(d.getElementsByTagName('head')[0]||d.getElementsByTagName('body')[0]).appendChild(g); }
+                function l() { if (hasLoaded) { return; } hasLoaded = true; window.doorbellOptions.windowLoaded = true; var g = d.createElement(t);g.id = 'doorbellScript';g.type = 'text/javascript';g.async = true;g.src = 'https://embed.doorbell.io/button/'+window.doorbellOptions['id']+'?t='+(new Date().getTime());(d.getElementsByTagName('head')[0]||d.getElementsByTagName('body')[0]).appendChild(g); if( document.getElementsByClassName('floating-action-button').length == 0 ) { g.classList = ["bottom_right"]; } else { g.classList = ["bottom_left"]; }; }
                 if (w.attachEvent) { w.attachEvent('onload', l); } else if (w.addEventListener) { w.addEventListener('load', l, false); } else { l(); }
                 if (d.readyState == 'complete') { l(); }
             }(window, document, 'script'));

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -41,7 +41,7 @@
       };
       (function(w, d, t) {
       var hasLoaded = false;
-      function l() { if (hasLoaded) { return; } hasLoaded = true; window.doorbellOptions.windowLoaded = true; var g = d.createElement(t);g.id = 'doorbellScript';g.type = 'text/javascript';g.async = true;g.src = 'https://embed.doorbell.io/button/'+window.doorbellOptions['id']+'?t='+(new Date().getTime());(d.getElementsByTagName('head')[0]||d.getElementsByTagName('body')[0]).appendChild(g); }
+      function l() { if (hasLoaded) { return; } hasLoaded = true; window.doorbellOptions.windowLoaded = true; var g = d.createElement(t);g.id = 'doorbellScript';g.type = 'text/javascript';g.async = true;g.src = 'https://embed.doorbell.io/button/'+window.doorbellOptions['id']+'?t='+(new Date().getTime());(d.getElementsByTagName('head')[0]||d.getElementsByTagName('body')[0]).appendChild(g); if( document.getElementsByClassName('floating-action-button').length == 0 ) { g.classList = ["bottom_right"]; } else { g.classList = ["bottom_left"]; }; }
       if (w.attachEvent) { w.attachEvent('onload', l); } else if (w.addEventListener) { w.addEventListener('load', l, false); } else { l(); }
       if (d.readyState == 'complete') { l(); }
       }(window, document, 'script'));


### PR DESCRIPTION
Added a small javascript check on the existance of the post fab that will move Doorbell's Feedback button to the left or right, to not block the boost & reply button when inside a thread.

The position is changed by changing the button class between "bottom_left" & "bottom_right", classes already provided by doorbell.