### PR TITLE
Fix avatar overlap issue in Witches theme

### DIFF
--- a/app/javascript/skins/glitch/witches/fixes.scss
+++ b/app/javascript/skins/glitch/witches/fixes.scss
@@ -1,3 +1,7 @@
 .status__content .status__content__text, .reply-indicator__content .status__content__text {
     display: block;
 }
+
+.status__avatar {
+    position: unset;
+}

--- a/app/javascript/skins/glitch/witches/fixes.scss
+++ b/app/javascript/skins/glitch/witches/fixes.scss
@@ -5,7 +5,7 @@
 .status__avatar {
     position: unset;
 }
-.status__info .status__display-name
+.status__info .status__display-name {
     display: unset;
     padding-right: 0px;
 }

--- a/app/javascript/skins/glitch/witches/fixes.scss
+++ b/app/javascript/skins/glitch/witches/fixes.scss
@@ -5,3 +5,7 @@
 .status__avatar {
     position: unset;
 }
+.status__info .status__display-name
+    display: unset;
+    padding-right: 0px;
+}


### PR DESCRIPTION
As far as I can tell this is the only issue that Witches has, this removes the position: absolute and just unsets it so that it's not covering up account names 

Also fixed the word wrapping in the notifications column so it looks normal